### PR TITLE
Disable files endpoint for site root.

### DIFF
--- a/ftw/jsonapi/endpoints/files.py
+++ b/ftw/jsonapi/endpoints/files.py
@@ -1,9 +1,9 @@
 from ftw.jsonapi.endpoints import Endpoint
 from ftw.jsonapi.interfaces import IGET
 from plone.dexterity.interfaces import IDexterityContent
+from Products.CMFCore.interfaces import IContentish
 from zope.component import adapts
 from zope.interface import alsoProvides
-from zope.interface import Interface
 from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces import NotFound
 
@@ -13,7 +13,7 @@ class GetFiles(Endpoint):
     """
 
     alsoProvides(IPublishTraverse)
-    adapts(Interface, IGET)
+    adapts(IContentish, IGET)
 
     def __init__(self, *args, **kwargs):
         super(GetFiles, self).__init__(*args, **kwargs)

--- a/ftw/jsonapi/tests/test_endpoints_files_get.py
+++ b/ftw/jsonapi/tests/test_endpoints_files_get.py
@@ -52,3 +52,9 @@ class TestFilesGETEndpoint(FunctionalTestCase):
         self.assertEquals(200, browser.response.status_code)
         self.assertEquals('text/x-python', browser.headers.get('Content-Type'))
         self.assertEquals('print "Hello World"\n', browser.contents)
+
+    @browsing
+    def test_portal_has_no_files_endpoint(self, browser):
+        self.grant('Manager')
+        browser.login().webdav('GET', view='api/files')
+        self.assertEquals(404, browser.response.status_code)


### PR DESCRIPTION
Only contentish content may have files in fields.
